### PR TITLE
Add ZIP upload endpoint for local order processing

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
+++ b/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
@@ -2,6 +2,7 @@ package br.com.portfoliopelusci.controller;
 
 
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import br.com.portfoliopelusci.config.OrganizadorProperties;
 import br.com.portfoliopelusci.service.OrganizadorService;
@@ -37,6 +38,18 @@ public class OrganizadorController {
             props.setDryRun(dryRun);
             service.processar();
             return "Processo concluído (dryRun=" + props.isDryRun() + ").";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Erro: " + e.getMessage();
+        }
+    }
+
+    /** Recebe um ZIP contendo as ordens e processa localmente */
+    @PostMapping("/upload")
+    public String organizarZip(@RequestParam("file") MultipartFile zip) {
+        try {
+            service.processarZip(zip);
+            return "Processo concluído (zip).";
         } catch (Exception e) {
             e.printStackTrace();
             return "Erro: " + e.getMessage();


### PR DESCRIPTION
## Summary
- add `/organizar/upload` endpoint to handle ZIP uploads
- process ZIP contents locally, logging each order folder
- classify due dates into R/Y/B and copy directories accordingly
- move folders missing from Excel into `não tem no documento` directory

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for br.com.portfoliopelusci:rest-spring-boot-java-pelusci:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68b03114796c83228b2a336d9f34dcfb