### PR TITLE
feat: create folders from excel

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
+++ b/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
@@ -44,6 +44,18 @@ public class OrganizadorController {
         }
     }
 
+    /** Cria pastas vazias para cada ordem presente na planilha */
+    @PostMapping("/folders")
+    public String criarPastas() {
+        try {
+            service.criarPastas();
+            return "Pastas processadas (dryRun=" + props.isDryRun() + ").";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Erro: " + e.getMessage();
+        }
+    }
+
     /** Recebe um ZIP contendo as ordens e processa localmente */
     @PostMapping("/upload")
     public String organizarZip(@RequestParam("file") MultipartFile zip) {


### PR DESCRIPTION
## Summary
- add service to create folders for each WORDER entry in the Excel sheet
- expose `/organizar/folders` endpoint to trigger directory creation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0370068ec83229b65ccf06cbe0ee7