### PR TITLE
Add zip processing from configured path

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/config/OrganizadorProperties.java
+++ b/src/main/java/br/com/portfoliopelusci/config/OrganizadorProperties.java
@@ -13,6 +13,9 @@ public class OrganizadorProperties {
     private String excelPath;
 
     @NotBlank
+    private String zipPath;
+
+    @NotBlank
     private String sourceBasePath;
 
     @NotBlank
@@ -64,6 +67,13 @@ public class OrganizadorProperties {
     }
     public void setExcelPath(String excelPath) {
         this.excelPath = excelPath;
+    }
+
+    public String getZipPath() {
+        return zipPath;
+    }
+    public void setZipPath(String zipPath) {
+        this.zipPath = zipPath;
     }
 
     public String getSourceBasePath() {

--- a/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
+++ b/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
@@ -67,4 +67,16 @@ public class OrganizadorController {
             return "Erro: " + e.getMessage();
         }
     }
+
+    /** Processa o ZIP localizado no caminho configurado */
+    @PostMapping("/zip")
+    public String organizarZipLocal() {
+        try {
+            service.processarZip();
+            return "Processo concluído (zip local).";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Erro: " + e.getMessage();
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ server:
 
 organizador:
   excel-path: "C:/Dev/Projeto Danilo/testes/TDW9FI 2608.xlsx"
+  zip-path: "C:/Dev/Projeto Danilo/testes/TDW9FI 2608.zip"
   source-base-path: "C:/Dev/Projeto Danilo/testes/pastasteste"
   dest-base-path: "C:/Dev/Projeto Danilo/testes/pastatestecopia"
   sheet-index: 0


### PR DESCRIPTION
## Summary
- allow configuring a zip file path in `OrganizadorProperties`
- unzip and process the configured zip without uploading
- expose `/organizar/zip` endpoint to trigger processing of the local zip

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e91cb6c8832293923e5e8f2bed41