### PR TITLE
Validação do caminho da pasta de ZIPs

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -236,7 +236,11 @@ public class OrganizadorService {
     }
 
     public void processarZips() throws IOException {
-        Path zipsDir = Path.of(props.getZipFolderPath());
+        String zipFolderPath = props.getZipFolderPath();
+        if (zipFolderPath == null || zipFolderPath.isBlank()) {
+            throw new IllegalArgumentException("Caminho da pasta de ZIPs não definido.");
+        }
+        Path zipsDir = Path.of(zipFolderPath);
         if (!Files.exists(zipsDir) || !Files.isDirectory(zipsDir)) {
             throw new IllegalArgumentException("Pasta de ZIPs não encontrada: " + zipsDir);
         }


### PR DESCRIPTION
## Summary
- validar existência do caminho da pasta de ZIPs antes de processar

## Testing
- `mvn -q test` *(falhou: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f55c84848322ab609caeaa823e24