### PR TITLE
Handle nested zip extraction and copying

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/config/OrganizadorProperties.java
+++ b/src/main/java/br/com/portfoliopelusci/config/OrganizadorProperties.java
@@ -16,6 +16,9 @@ public class OrganizadorProperties {
     private String zipFolderPath;
 
     @NotBlank
+    private String parentZipPath;
+
+    @NotBlank
     private String sourceBasePath;
 
     @NotBlank
@@ -74,6 +77,13 @@ public class OrganizadorProperties {
     }
     public void setZipFolderPath(String zipFolderPath) {
         this.zipFolderPath = zipFolderPath;
+    }
+
+    public String getParentZipPath() {
+        return parentZipPath;
+    }
+    public void setParentZipPath(String parentZipPath) {
+        this.parentZipPath = parentZipPath;
     }
 
     public String getSourceBasePath() {

--- a/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
+++ b/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
@@ -79,4 +79,16 @@ public class OrganizadorController {
             return "Erro: " + e.getMessage();
         }
     }
+
+    /** Processa um ZIP que contém outros ZIPs */
+    @PostMapping("/zip-parent")
+    public String organizarZipPai() {
+        try {
+            service.processarZipPai();
+            return "Processo concluído (zip pai).";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Erro: " + e.getMessage();
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ server:
 organizador:
   excel-path: "C:/Dev/Projeto Danilo/testes/TDW9FI 2608.xlsx"
   zip-folder-path: "C:/Dev/Projeto Danilo/testes/zips"
+  parent-zip-path: "C:/Dev/Projeto Danilo/testes/pai.zip"
   source-base-path: "C:/Dev/Projeto Danilo/testes/pastasteste"
   dest-base-path: "C:/Dev/Projeto Danilo/testes/pastatestecopia"
   sheet-index: 0


### PR DESCRIPTION
## Summary
- add `parentZipPath` configuration for root ZIP location
- extract nested ZIPs and copy order folders to target directory
- expose `/organizar/zip-parent` endpoint to trigger nested ZIP processing

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fb5e9fe8832294e8eb8906e455dd