### PR TITLE
Copy orders to centralized folder

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/config/OrganizadorProperties.java
+++ b/src/main/java/br/com/portfoliopelusci/config/OrganizadorProperties.java
@@ -24,6 +24,9 @@ public class OrganizadorProperties {
     @NotBlank
     private String destBasePath;
 
+    @NotBlank
+    private String allOrdersBasePath;
+
     @NotNull
     private Integer sheetIndex = 0;
 
@@ -98,6 +101,13 @@ public class OrganizadorProperties {
     }
     public void setDestBasePath(String destBasePath) {
         this.destBasePath = destBasePath;
+    }
+
+    public String getAllOrdersBasePath() {
+        return allOrdersBasePath;
+    }
+    public void setAllOrdersBasePath(String allOrdersBasePath) {
+        this.allOrdersBasePath = allOrdersBasePath;
     }
 
     public Integer getSheetIndex() {

--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -312,8 +312,10 @@ public class OrganizadorService {
 
         Path extractBase = Path.of(props.getSourceBasePath());
         Path destBase = Path.of(props.getDestBasePath());
+        Path allOrdersBase = Path.of(props.getAllOrdersBasePath());
         Files.createDirectories(extractBase);
         Files.createDirectories(destBase);
+        Files.createDirectories(allOrdersBase);
 
         Path tempDir = Files.createTempDirectory("zip-pai");
         try (InputStream in = Files.newInputStream(zipPai)) {
@@ -332,14 +334,20 @@ public class OrganizadorService {
 
                 try (Stream<Path> orders = Files.list(inspectorDir)) {
                     for (Path orderDir : orders.filter(Files::isDirectory).collect(Collectors.toList())) {
-                        Path target = destBase.resolve(baseName).resolve(orderDir.getFileName());
-                        Path finalTarget = uniquePath(target);
+                        Path inspectorTarget = destBase.resolve(baseName).resolve(orderDir.getFileName());
+                        Path finalInspectorTarget = uniquePath(inspectorTarget);
+                        Path allOrdersTarget = allOrdersBase.resolve(orderDir.getFileName());
+                        Path finalAllOrdersTarget = uniquePath(allOrdersTarget);
                         if (props.isDryRun()) {
-                            log("[DRY-RUN] Copiar: " + orderDir + " -> " + finalTarget);
+                            log("[DRY-RUN] Copiar: " + orderDir + " -> " + finalInspectorTarget);
+                            log("[DRY-RUN] Copiar: " + orderDir + " -> " + finalAllOrdersTarget);
                         } else {
-                            Files.createDirectories(finalTarget.getParent());
-                            copyDirectory(orderDir, finalTarget);
-                            log("COPIADO: " + orderDir.getFileName() + " -> " + finalTarget);
+                            Files.createDirectories(finalInspectorTarget.getParent());
+                            copyDirectory(orderDir, finalInspectorTarget);
+                            Files.createDirectories(finalAllOrdersTarget.getParent());
+                            copyDirectory(orderDir, finalAllOrdersTarget);
+                            log("COPIADO: " + orderDir.getFileName() + " -> " + finalInspectorTarget);
+                            log("COPIADO: " + orderDir.getFileName() + " -> " + finalAllOrdersTarget);
                         }
                     }
                 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,7 @@ organizador:
   parent-zip-path: "C:/Dev/Projeto Danilo/testes/pai.zip"
   source-base-path: "C:/Dev/Projeto Danilo/testes/pastasteste"
   dest-base-path: "C:/Dev/Projeto Danilo/testes/pastatestecopia"
+  all-orders-base-path: "C:/Dev/Projeto Danilo/testes/todas-ordens"
   sheet-index: 0
   timezone: "America/Sao_Paulo"
   columns:


### PR DESCRIPTION
## Summary
- allow processing parent ZIPs to also copy each order into a global aggregated directory
- add `all-orders-base-path` configuration property with example value in `application.yml`

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b18159656c8322aede19eefa4b5868