### PR TITLE
Handle nested ZIP parent with organize pass

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -321,10 +321,14 @@ public class OrganizadorService {
         }
 
         try (Stream<Path> innerStream = Files.list(tempDir)) {
-            for (Path innerZip : innerStream.filter(p -> Files.isRegularFile(p) && p.toString().toLowerCase().endsWith(".zip")).collect(Collectors.toList())) {
+            for (Path innerZip : innerStream
+                    .filter(p -> Files.isRegularFile(p) && p.toString().toLowerCase().endsWith(".zip"))
+                    .collect(Collectors.toList())) {
                 String inspectorName = innerZip.getFileName().toString();
-                String baseName = inspectorName.endsWith(".zip") ? inspectorName.substring(0, inspectorName.length() - 4) : inspectorName;
-                Path inspectorDir = destBase.resolve(baseName);
+                String baseName = inspectorName.endsWith(".zip")
+                        ? inspectorName.substring(0, inspectorName.length() - 4)
+                        : inspectorName;
+                Path inspectorDir = tempDir.resolve(baseName);
                 if (Files.exists(inspectorDir)) {
                     if (props.isOverwriteExisting()) {
                         if (!props.isDryRun()) deleteRecursively(inspectorDir);
@@ -363,6 +367,14 @@ public class OrganizadorService {
                     }
                 }
             }
+        }
+
+        String originalSource = props.getSourceBasePath();
+        try {
+            props.setSourceBasePath(allOrdersBase.toString());
+            processar();
+        } finally {
+            props.setSourceBasePath(originalSource);
         }
     }
 


### PR DESCRIPTION
## Summary
- Process parent ZIPs that contain inspector ZIPs by extracting internally
- Aggregate all order folders and run the standard organize process

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b58046c6f08322a4268e12ee4a9cda