### PR TITLE
feat: process nested zips recursively

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -320,9 +320,10 @@ public class OrganizadorService {
             unzip(in, tempDir);
         }
 
-        try (Stream<Path> innerStream = Files.list(tempDir)) {
+        try (Stream<Path> innerStream = Files.walk(tempDir)) {
             for (Path innerZip : innerStream
-                    .filter(p -> Files.isRegularFile(p) && p.toString().toLowerCase().endsWith(".zip"))
+                    .filter(Files::isRegularFile)
+                    .filter(p -> p.toString().toLowerCase().endsWith(".zip"))
                     .collect(Collectors.toList())) {
                 String inspectorName = innerZip.getFileName().toString();
                 String baseName = inspectorName.endsWith(".zip")


### PR DESCRIPTION
## Summary
- Traverse `processarZipPai`'s temp directory recursively using `Files.walk`
- Filter paths to regular `.zip` files before extraction

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b587cd291c83228f2170ea9c440fba