### PR TITLE
feat: add zip-parent endpoint with path

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
+++ b/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
@@ -138,4 +138,23 @@ public class OrganizadorController {
             return "Erro: " + e.getMessage();
         }
     }
+
+    /**
+     * Variante que permite informar diretamente o caminho do ZIP pai a
+     * ser processado. O ZIP indicado é descompactado e cada ZIP interno é
+     * tratado como no endpoint padrão.
+     *
+     * @param path caminho completo do arquivo ZIP pai
+     * @return mensagem sobre a conclusão do processamento
+     */
+    @PostMapping("/zip-parent/path")
+    public String organizarZipPai(@RequestParam("path") String path) {
+        try {
+            service.processarZipPai(path);
+            return "Processo concluído (zip pai).";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Erro: " + e.getMessage();
+        }
+    }
 }

--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -301,7 +301,10 @@ public class OrganizadorService {
     }
 
     public void processarZipPai() throws IOException {
-        String parentZipPath = props.getParentZipPath();
+        processarZipPai(props.getParentZipPath());
+    }
+
+    public void processarZipPai(String parentZipPath) throws IOException {
         if (parentZipPath == null || parentZipPath.isBlank()) {
             throw new IllegalArgumentException("Caminho do ZIP pai não definido.");
         }


### PR DESCRIPTION
## Summary
- allow processing parent ZIPs by supplying a custom path
- expose new endpoint `/organizar/zip-parent/path` that receives the path parameter

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5978557588322a0d6913b0e29387e