### PR TITLE
feat: add endpoint to extract all zips from directory

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
+++ b/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
@@ -157,4 +157,21 @@ public class OrganizadorController {
             return "Erro: " + e.getMessage();
         }
     }
+
+    /**
+     * Extrai todos os arquivos ZIP encontrados na pasta informada.
+     *
+     * @param path caminho da pasta contendo os arquivos ZIP
+     * @return mensagem indicando o resultado da extração
+     */
+    @PostMapping("/extrairTodos")
+    public String extrairTodos(@RequestParam("path") String path) {
+        try {
+            service.extrairTodos(path);
+            return "Extração concluída.";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Erro: " + e.getMessage();
+        }
+    }
 }

--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -355,6 +355,40 @@ public class OrganizadorService {
     }
 
     /**
+     * Extrai todos os arquivos ZIP presentes na pasta informada.
+     * Cada ZIP é descompactado para uma subpasta com o mesmo nome
+     * (sem a extensão ".zip").
+     *
+     * @param folderPath caminho da pasta contendo os arquivos ZIP
+     */
+    public void extrairTodos(String folderPath) throws IOException {
+        if (folderPath == null || folderPath.isBlank()) {
+            throw new IllegalArgumentException("Caminho da pasta não definido.");
+        }
+
+        Path dir = Path.of(folderPath);
+        if (!Files.exists(dir) || !Files.isDirectory(dir)) {
+            throw new IllegalArgumentException("Pasta de ZIPs não encontrada: " + dir);
+        }
+
+        try (Stream<Path> stream = Files.list(dir)) {
+            List<Path> zips = stream
+                    .filter(p -> Files.isRegularFile(p) && p.toString().toLowerCase().endsWith(".zip"))
+                    .collect(Collectors.toList());
+
+            for (Path zipPath : zips) {
+                String fileName = zipPath.getFileName().toString();
+                String baseName = fileName.endsWith(".zip") ? fileName.substring(0, fileName.length() - 4) : fileName;
+                Path targetDir = dir.resolve(baseName);
+                Files.createDirectories(targetDir);
+                try (InputStream in = Files.newInputStream(zipPath)) {
+                    unzip(in, targetDir);
+                }
+            }
+        }
+    }
+
+    /**
      * Processa o arquivo ZIP pai configurado nas propriedades.
      */
     public void processarZipPai() throws IOException {


### PR DESCRIPTION
## Summary
- add service method `extrairTodos` to unzip all files from a given folder
- expose `/organizar/extrairTodos` endpoint to trigger extraction via path parameter

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for br.com.portfoliopelusci:rest-spring-boot-java-pelusci:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a529929083228715d50db005bac1