### PR TITLE
Log extracted ZIP folders in extrairTodos

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -383,6 +383,7 @@ public class OrganizadorService {
                 Files.createDirectories(targetDir);
                 try (InputStream in = Files.newInputStream(zipPath)) {
                     unzip(in, targetDir);
+                    log("Arquivo ZIP extraído: " + fileName + " para " + targetDir);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- log extraction path for ZIP files in `extrairTodos`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a874d8c88322b699aca60fed8ace