### PR TITLE
Fix nested folders when extracting parent ZIP

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -455,6 +455,7 @@ public class OrganizadorService {
                     try (InputStream in = Files.newInputStream(innerZip)) {
                         unzip(in, inspectorDir);
                     }
+                    fixNestedFolder(inspectorDir, baseName);
                 }
 
                 // Copia todas as ordens extraídas para o diretório consolidado
@@ -592,6 +593,22 @@ public class OrganizadorService {
                     throw new RuntimeException("Erro ao deletar: " + p + " -> " + e.getMessage(), e);
                 }
             });
+        }
+    }
+
+    /**
+     * Remove uma pasta duplicada quando o conteúdo do ZIP já contém
+     * um diretório com o mesmo nome do destino.
+     */
+    private static void fixNestedFolder(Path dir, String baseName) throws IOException {
+        Path nested = dir.resolve(baseName);
+        if (Files.exists(nested) && Files.isDirectory(nested)) {
+            try (Stream<Path> children = Files.list(nested)) {
+                for (Path child : children.collect(Collectors.toList())) {
+                    Files.move(child, dir.resolve(child.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+            deleteRecursively(nested);
         }
     }
 

--- a/src/test/java/br/com/portfoliopelusci/service/OrganizadorServiceTest.java
+++ b/src/test/java/br/com/portfoliopelusci/service/OrganizadorServiceTest.java
@@ -40,7 +40,7 @@ class OrganizadorServiceTest {
         OrganizadorService service = new OrganizadorService(props);
         service.processarZipPai();
 
-        Path ordemDest = dest.resolve("0828-Geovane").resolve("350394452").resolve("data.txt");
+        Path ordemDest = dest.resolve("Geovane").resolve("0828-Geovane").resolve("350394452").resolve("data.txt");
         Path ordemAll = allOrders.resolve("350394452").resolve("data.txt");
         assertTrue(Files.exists(ordemDest));
         assertTrue(Files.exists(ordemAll));


### PR DESCRIPTION
## Summary
- flatten nested directories when extracting inspector ZIPs from a parent ZIP
- adjust tests for new inspector folder layout

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ae115cf08322ba4e6320a5229f1f