### PR TITLE
Organize child zips during parent zip processing

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -383,8 +383,10 @@ public class OrganizadorService {
                 Files.createDirectories(targetDir);
                 try (InputStream in = Files.newInputStream(zipPath)) {
                     unzip(in, targetDir);
-                    log("Arquivo ZIP extraído: " + fileName + " para " + targetDir);
                 }
+                // Remove eventual pasta duplicada criada pelo ZIP
+                fixNestedFolder(targetDir, baseName);
+                log("Arquivo ZIP extraído: " + fileName + " para " + targetDir);
             }
         }
     }
@@ -456,6 +458,8 @@ public class OrganizadorService {
                         unzip(in, inspectorDir);
                     }
                     fixNestedFolder(inspectorDir, baseName);
+                    // Extrai eventuais ZIPs de ordens já organizando as pastas
+                    extrairTodos(inspectorDir.toString());
                 }
 
                 // Copia todas as ordens extraídas para o diretório consolidado


### PR DESCRIPTION
## Summary
- organize extracted child ZIP folders by flattening redundant root folders
- extract nested order ZIPs when processing parent inspector ZIPs
- test parent ZIP processing with nested order ZIPs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b07d27208322b042bf3832c79f60