### PR TITLE
Process extracted zips automatically

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -355,9 +355,11 @@ public class OrganizadorService {
     }
 
     /**
-     * Extrai todos os arquivos ZIP presentes na pasta informada.
-     * Cada ZIP é descompactado para uma subpasta com o mesmo nome
-     * (sem a extensão ".zip").
+     * Extrai todos os arquivos ZIP presentes na pasta informada e, em
+     * seguida, processa o conteúdo extraído utilizando o método principal
+     * {@link #processar()}, enviando o resultado para {@code destBasePath}.
+     * Cada ZIP é descompactado para uma subpasta com o mesmo nome (sem a
+     * extensão ".zip").
      *
      * @param folderPath caminho da pasta contendo os arquivos ZIP
      */
@@ -388,6 +390,15 @@ public class OrganizadorService {
                 fixNestedFolder(targetDir, baseName);
                 log("Arquivo ZIP extraído: " + fileName + " para " + targetDir);
             }
+        }
+
+        // Após a extração, processa as ordens movendo-as para destBasePath
+        String originalSource = props.getSourceBasePath();
+        try {
+            props.setSourceBasePath(dir.toString());
+            processar();
+        } finally {
+            props.setSourceBasePath(originalSource);
         }
     }
 

--- a/src/test/java/br/com/portfoliopelusci/service/OrganizadorServiceTest.java
+++ b/src/test/java/br/com/portfoliopelusci/service/OrganizadorServiceTest.java
@@ -130,6 +130,33 @@ class OrganizadorServiceTest {
         assertEquals("dados", Files.readString(ordemAll, StandardCharsets.UTF_8));
     }
 
+    @Test
+    void extrairTodosProcessaOrdensParaDestBase() throws IOException {
+        Path temp = Files.createTempDirectory("org4");
+        Path dest = temp.resolve("dest");
+        Files.createDirectories(dest);
+
+        createOrderZip(temp, "350394452", "dados");
+        Path excel = createExcel(temp.resolve("plan.xlsx"), "350394452", "A");
+
+        OrganizadorProperties props = new OrganizadorProperties();
+        props.setExcelPath(excel.toString());
+        props.setSourceBasePath(temp.toString());
+        props.setDestBasePath(dest.toString());
+        props.setZipFolderPath(temp.toString());
+        props.setParentZipPath(temp.resolve("pai.zip").toString());
+        props.setAllOrdersBasePath(dest.resolve("todas").toString());
+        props.setDryRun(false);
+        props.setOverwriteExisting(true);
+
+        OrganizadorService service = new OrganizadorService(props);
+        service.extrairTodos(temp.toString());
+
+        Path ordemDest = dest.resolve("A").resolve("350394452 A N").resolve("data.txt");
+        assertTrue(Files.exists(ordemDest));
+        assertEquals("dados", Files.readString(ordemDest, StandardCharsets.UTF_8));
+    }
+
     private static Path createExcel(Path file, String numero, String tipo) throws IOException {
         try (Workbook wb = new XSSFWorkbook()) {
             Sheet sheet = wb.createSheet();


### PR DESCRIPTION
## Summary
- Automatically run main processing after extracting ZIP archives to the source folder, moving results to `destBasePath`.
- Add regression test for processing during ZIP extraction.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c0678138832288aae5bdcb094e65