### PR TITLE
Renomeia pastas de ordens conforme nomes finais

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -476,9 +476,62 @@ public class OrganizadorService {
                 }
             }
         }
+
+        // Após organizar todas as ordens, renomeia as pastas de origem para
+        // refletir o nome final presente em allOrdersBasePath.
+        renameLeafFolders(destBase, allOrdersBase);
     }
 
     /* ===== Helpers ===== */
+
+    /**
+     * Renomeia os diretórios de último nível em {@code sourceRoot} para que
+     * correspondam aos nomes gerados em {@code allOrdersRoot}. O mapeamento é
+     * feito com base no número da ordem, extraído do nome final (antes do
+     * primeiro espaço).
+     */
+    private void renameLeafFolders(Path sourceRoot, Path allOrdersRoot) throws IOException {
+        if (!Files.exists(sourceRoot) || !Files.isDirectory(sourceRoot)) return;
+        if (!Files.exists(allOrdersRoot) || !Files.isDirectory(allOrdersRoot)) return;
+
+        Map<String, String> nameMap = new HashMap<>();
+        try (Stream<Path> typeDirs = Files.list(allOrdersRoot)) {
+            for (Path typeDir : typeDirs.filter(Files::isDirectory).collect(Collectors.toList())) {
+                try (Stream<Path> orders = Files.list(typeDir)) {
+                    for (Path order : orders.filter(Files::isDirectory).collect(Collectors.toList())) {
+                        String finalName = order.getFileName().toString();
+                        String numero = finalName.split(" ")[0];
+                        nameMap.put(numero, finalName);
+                    }
+                }
+            }
+        }
+
+        if (nameMap.isEmpty()) return;
+
+        try (Stream<Path> dirs = Files.walk(sourceRoot)) {
+            for (Path dir : dirs.filter(Files::isDirectory).collect(Collectors.toList())) {
+                if (!isLeaf(dir)) continue;
+                String nome = dir.getFileName().toString();
+                String novoNome = nameMap.get(nome);
+                if (novoNome != null && !novoNome.equals(nome)) {
+                    Path target = uniquePath(dir.getParent().resolve(safeName(novoNome)));
+                    if (props.isDryRun()) {
+                        log("[DRY-RUN] Renomear: " + dir + " -> " + target);
+                    } else {
+                        Files.move(dir, target);
+                    }
+                }
+            }
+        }
+    }
+
+    /** Verifica se o diretório não possui subpastas. */
+    private static boolean isLeaf(Path dir) throws IOException {
+        try (Stream<Path> stream = Files.list(dir)) {
+            return stream.noneMatch(Files::isDirectory);
+        }
+    }
 
     /**
      * Descompacta um arquivo ZIP a partir de um {@link InputStream}

--- a/src/test/java/br/com/portfoliopelusci/service/OrganizadorServiceTest.java
+++ b/src/test/java/br/com/portfoliopelusci/service/OrganizadorServiceTest.java
@@ -44,7 +44,7 @@ class OrganizadorServiceTest {
         OrganizadorService service = new OrganizadorService(props);
         service.processarZipPai();
 
-        Path ordemDest = dest.resolve("Geovane").resolve("0828-Geovane").resolve("350394452").resolve("data.txt");
+        Path ordemDest = dest.resolve("Geovane").resolve("0828-Geovane").resolve("350394452 A N").resolve("data.txt");
         Path ordemAll = allOrders.resolve("A").resolve("350394452 A N").resolve("data.txt");
         assertTrue(Files.exists(ordemDest));
         assertTrue(Files.exists(ordemAll));
@@ -123,7 +123,7 @@ class OrganizadorServiceTest {
         OrganizadorService service = new OrganizadorService(props);
         service.processarZipPai();
 
-        Path ordemDest = dest.resolve("Geovane").resolve("0828-Geovane").resolve("350394452").resolve("data.txt");
+        Path ordemDest = dest.resolve("Geovane").resolve("0828-Geovane").resolve("350394452 A N").resolve("data.txt");
         Path ordemAll = allOrders.resolve("A").resolve("350394452 A N").resolve("data.txt");
         assertTrue(Files.exists(ordemDest));
         assertTrue(Files.exists(ordemAll));


### PR DESCRIPTION
## Summary
- renomeia pastas de ordens após processar zip pai para refletir nomes finais de todas as ordens
- adiciona utilitários para renomear diretórios de último nível
- ajusta testes para esperar novo nome das pastas

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c5b188a48322a63b63262877011c