### PR TITLE
Renomeia pastas de ordens conforme nomes finais

### DIFF
--- a/src/test/java/br/com/portfoliopelusci/service/OrganizadorServiceTest.java
+++ b/src/test/java/br/com/portfoliopelusci/service/OrganizadorServiceTest.java
@@ -44,7 +44,7 @@ class OrganizadorServiceTest {
         OrganizadorService service = new OrganizadorService(props);
         service.processarZipPai();
 
-        Path ordemDest = dest.resolve("Geovane").resolve("0828-Geovane").resolve("350394452").resolve("data.txt");
+        Path ordemDest = dest.resolve("Geovane").resolve("0828-Geovane").resolve("350394452 A N").resolve("data.txt");
         Path ordemAll = allOrders.resolve("A").resolve("350394452 A N").resolve("data.txt");
         assertTrue(Files.exists(ordemDest));
         assertTrue(Files.exists(ordemAll));
@@ -123,7 +123,7 @@ class OrganizadorServiceTest {
         OrganizadorService service = new OrganizadorService(props);
         service.processarZipPai();
 
-        Path ordemDest = dest.resolve("Geovane").resolve("0828-Geovane").resolve("350394452").resolve("data.txt");
+        Path ordemDest = dest.resolve("Geovane").resolve("0828-Geovane").resolve("350394452 A N").resolve("data.txt");
         Path ordemAll = allOrders.resolve("A").resolve("350394452 A N").resolve("data.txt");
         assertTrue(Files.exists(ordemDest));
         assertTrue(Files.exists(ordemAll));


### PR DESCRIPTION
## Summary
- renomeia pastas de ordens após processar zip pai para refletir nomes finais de todas as ordens
- adiciona utilitários para renomear diretórios de último nível
- ajusta testes para esperar novo nome das pastas
- refatora renomeação para mapear nomes finais via `Files.walk` e verificar folhas com segurança

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c5b188a48322a63b63262877011c