### PR TITLE
feat: allow runtime configuration of directories

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
+++ b/src/main/java/br/com/portfoliopelusci/controller/OrganizadorController.java
@@ -159,6 +159,38 @@ public class OrganizadorController {
     }
 
     /**
+     * Atualiza dinamicamente os caminhos utilizados pelo serviço para localizar
+     * a planilha e as pastas de origem e destino. Também permite sobrescrever os
+     * diretórios relacionados ao processamento de arquivos ZIP.
+     *
+     * @param excel caminho da planilha Excel
+     * @param source pasta base onde estão as ordens de serviço
+     * @param dest pasta base onde as ordens serão copiadas
+     * @param zipFolder (opcional) pasta que contém arquivos ZIP a serem
+     *                  processados
+     * @param parentZip (opcional) caminho do arquivo ZIP "pai"
+     * @param allOrders (opcional) pasta central onde todas as ordens serão
+     *                  armazenadas
+     * @return mensagem indicando que as configurações foram atualizadas
+     */
+    @PostMapping("/paths")
+    public String configurarCaminhos(
+            @RequestParam("excel") String excel,
+            @RequestParam("source") String source,
+            @RequestParam("dest") String dest,
+            @RequestParam(value = "zipFolder", required = false) String zipFolder,
+            @RequestParam(value = "parentZip", required = false) String parentZip,
+            @RequestParam(value = "allOrders", required = false) String allOrders) {
+        props.setExcelPath(excel);
+        props.setSourceBasePath(source);
+        props.setDestBasePath(dest);
+        if (zipFolder != null) props.setZipFolderPath(zipFolder);
+        if (parentZip != null) props.setParentZipPath(parentZip);
+        if (allOrders != null) props.setAllOrdersBasePath(allOrders);
+        return "Caminhos atualizados.";
+    }
+
+    /**
      * Extrai todos os arquivos ZIP encontrados na pasta informada.
      *
      * @param path caminho da pasta contendo os arquivos ZIP

--- a/src/test/java/br/com/portfoliopelusci/controller/OrganizadorControllerTest.java
+++ b/src/test/java/br/com/portfoliopelusci/controller/OrganizadorControllerTest.java
@@ -1,0 +1,44 @@
+package br.com.portfoliopelusci.controller;
+
+import br.com.portfoliopelusci.config.OrganizadorProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OrganizadorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private OrganizadorProperties props;
+
+    @Test
+    void atualizaCaminhos() throws Exception {
+        Path temp = Files.createTempDirectory("orgPaths");
+        String excel = temp.resolve("plan.xlsx").toString();
+        String source = temp.resolve("src").toString();
+        String dest = temp.resolve("dest").toString();
+
+        mockMvc.perform(post("/organizar/paths")
+                        .param("excel", excel)
+                        .param("source", source)
+                        .param("dest", dest))
+                .andExpect(status().isOk());
+
+        assertEquals(excel, props.getExcelPath());
+        assertEquals(source, props.getSourceBasePath());
+        assertEquals(dest, props.getDestBasePath());
+    }
+}


### PR DESCRIPTION
## Summary
- add endpoint to configure Excel and folder paths
- cover new endpoint with a controller test

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ddbff51083229b3c9b61e5b2b95a