### PR TITLE
feat: append missing rows to existing Excel

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/config/OrganizadorProperties.java
+++ b/src/main/java/br/com/portfoliopelusci/config/OrganizadorProperties.java
@@ -13,6 +13,9 @@ public class OrganizadorProperties {
     private String excelPath;
 
     @NotBlank
+    private String otherExcelPath;
+
+    @NotBlank
     private String zipFolderPath;
 
     @NotBlank
@@ -75,6 +78,13 @@ public class OrganizadorProperties {
     }
     public void setExcelPath(String excelPath) {
         this.excelPath = excelPath;
+    }
+
+    public String getOtherExcelPath() {
+        return otherExcelPath;
+    }
+    public void setOtherExcelPath(String otherExcelPath) {
+        this.otherExcelPath = otherExcelPath;
     }
 
     public String getZipFolderPath() {

--- a/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
+++ b/src/main/java/br/com/portfoliopelusci/service/OrganizadorService.java
@@ -8,6 +8,7 @@ import br.com.portfoliopelusci.config.OrganizadorProperties;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.*;
 import java.text.Normalizer;
 import java.time.*;
@@ -166,6 +167,13 @@ public class OrganizadorService {
                 Files.move(dir, destino);
             }
             log("SEM PLANILHA: " + dir.getFileName());
+        }
+
+        // Atualiza outra planilha adicionando entradas ausentes
+        String otherPath = props.getOtherExcelPath();
+        if (otherPath != null && !otherPath.isBlank()) {
+            Path other = Path.of(otherPath);
+            mergeMissingRows(excel, other, sheetIndex, dryRun);
         }
     }
 
@@ -605,6 +613,100 @@ public class OrganizadorService {
             catch (DateTimeParseException ignored) {}
         }
         return null;
+    }
+
+    /**
+     * Atualiza a planilha de destino adicionando linhas ausentes
+     * e organizando as colunas conforme o mapeamento desejado.
+     */
+    private void mergeMissingRows(Path source, Path dest, int sheetIndex, boolean dryRun) throws IOException {
+        try (Workbook srcWb = new XSSFWorkbook(Files.newInputStream(source));
+             Workbook dstWb = Files.exists(dest)
+                     ? new XSSFWorkbook(Files.newInputStream(dest))
+                     : new XSSFWorkbook()) {
+
+            DataFormatter fmt = new DataFormatter();
+
+            Sheet srcSheet = srcWb.getSheetAt(sheetIndex);
+            if (srcSheet == null) {
+                throw new IllegalArgumentException("Aba " + sheetIndex + " não encontrada no Excel.");
+            }
+            Row srcHeader = srcSheet.getRow(srcSheet.getFirstRowNum());
+            if (srcHeader == null) {
+                throw new IllegalArgumentException("Cabeçalho não encontrado na planilha.");
+            }
+            Map<String, Integer> srcMap = mapHeader(srcHeader, fmt);
+
+            int idxDate      = idx(srcMap, "DUEDATE");
+            int idxInspector = idx(srcMap, "INSPECTOR");
+            int idxAddress   = idx(srcMap, "ADDRESS1");
+            int idxCity      = idx(srcMap, "CITY");
+            int idxZip       = idx(srcMap, "ZIP");
+            int idxOtype     = idx(srcMap, "OTYPE");
+            int idxWorder    = idx(srcMap, "WORDER");
+
+            Sheet dstSheet;
+            if (dstWb.getNumberOfSheets() == 0) {
+                dstSheet = dstWb.createSheet(srcSheet.getSheetName());
+                Row header = dstSheet.createRow(0);
+                String[] headers = {"Data", "Inspector", "Address", "City", "zipcode", "OTYPE", "Worder"};
+                for (int i = 0; i < headers.length; i++) {
+                    header.createCell(i).setCellValue(headers[i]);
+                }
+            } else {
+                dstSheet = dstWb.getSheetAt(0);
+            }
+
+            Row dstHeader = dstSheet.getRow(dstSheet.getFirstRowNum());
+            Map<String, Integer> dstMap = mapHeader(dstHeader, fmt);
+            int dstIdxWorder = idx(dstMap, "Worder");
+
+            Set<String> existentes = new HashSet<>();
+            int tFirst = dstSheet.getFirstRowNum() + 1;
+            int tLast = dstSheet.getLastRowNum();
+            for (int r = tFirst; r <= tLast; r++) {
+                Row row = dstSheet.getRow(r);
+                if (row == null) continue;
+                String w = fmt.formatCellValue(row.getCell(dstIdxWorder)).trim();
+                if (!w.isBlank()) existentes.add(w);
+            }
+
+            int destRowNum = tLast + 1;
+            int sFirst = srcSheet.getFirstRowNum() + 1;
+            int sLast  = srcSheet.getLastRowNum();
+            for (int r = sFirst; r <= sLast; r++) {
+                Row sRow = srcSheet.getRow(r);
+                if (sRow == null) continue;
+                String worder = fmt.formatCellValue(sRow.getCell(idxWorder)).trim();
+                if (worder.isBlank() || existentes.contains(worder)) {
+                    continue;
+                }
+                if (dryRun) {
+                    log("[DRY-RUN] Adicionar Worder=" + worder + " ao Excel: " + dest);
+                } else {
+                    Row dRow = dstSheet.createRow(destRowNum++);
+                    dRow.createCell(0).setCellValue(fmt.formatCellValue(sRow.getCell(idxDate)));
+                    dRow.createCell(1).setCellValue(fmt.formatCellValue(sRow.getCell(idxInspector)));
+                    dRow.createCell(2).setCellValue(fmt.formatCellValue(sRow.getCell(idxAddress)));
+                    dRow.createCell(3).setCellValue(fmt.formatCellValue(sRow.getCell(idxCity)));
+                    dRow.createCell(4).setCellValue(fmt.formatCellValue(sRow.getCell(idxZip)));
+                    dRow.createCell(5).setCellValue(fmt.formatCellValue(sRow.getCell(idxOtype)));
+                    dRow.createCell(6).setCellValue(worder);
+                }
+                existentes.add(worder);
+            }
+
+            if (dryRun) {
+                log("[DRY-RUN] Atualizar planilha: " + dest);
+            } else {
+                Path parent = dest.getParent();
+                if (parent != null) Files.createDirectories(parent);
+                try (OutputStream out = Files.newOutputStream(dest)) {
+                    dstWb.write(out);
+                }
+                log("PLANILHA ATUALIZADA: " + dest);
+            }
+        }
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ server:
 
 organizador:
   excel-path: "C:/Dev/Projeto Danilo/testes/TDW9FI 2608.xlsx"
+  other-excel-path: "C:/Dev/Projeto Danilo/testes/TDW9FI 2608-output.xlsx"
   zip-folder-path: "C:/Dev/Projeto Danilo/testes/zips"
   parent-zip-path: "C:/Dev/Projeto Danilo/testes/pai.zip"
   source-base-path: "C:/Dev/Projeto Danilo/testes/pastasteste"


### PR DESCRIPTION
## Summary
- add configuration for comparing with an external Excel file
- merge rows into that file when Worder is missing, mapping columns to Data, Inspector, Address, City, zipcode, OTYPE, and Worder

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because Maven Central was unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba50cc1b5c83229d8c831dce6f6591