### PR TITLE
Documenta retorno do endpoint de importação de ZIP no Swagger

### DIFF
--- a/src/main/java/br/com/portfoliopelusci/inspecao/controller/InspecaoUploadController.java
+++ b/src/main/java/br/com/portfoliopelusci/inspecao/controller/InspecaoUploadController.java
@@ -2,6 +2,11 @@ package br.com.portfoliopelusci.inspecao.controller;
 
 import br.com.portfoliopelusci.inspecao.dto.UploadZipResponse;
 import br.com.portfoliopelusci.inspecao.service.UploadInspecaoZipService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,7 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 
 @RestController
-@RequestMapping("/inspecoes")
+@RequestMapping({"/inspecoes", "/foto-inspections"})
 public class InspecaoUploadController {
 
     private final UploadInspecaoZipService service;
@@ -22,7 +27,23 @@ public class InspecaoUploadController {
         this.service = service;
     }
 
-    @PostMapping("/upload-zip")
+    @Operation(
+            summary = "Importa ZIP de fotos de inspeção",
+            description = "Recebe um arquivo ZIP, processa as fotos por inspeção e retorna um resumo da importação."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "ZIP processado com sucesso.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UploadZipResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Arquivo inválido para processamento."),
+            @ApiResponse(responseCode = "500", description = "Erro inesperado ao processar ZIP.")
+    })
+    @PostMapping({"/upload-zip", "/import-zip"})
     public ResponseEntity<UploadZipResponse> uploadZip(@RequestParam("file") MultipartFile file) throws IOException {
         UploadZipResponse response = service.processar(file);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/br/com/portfoliopelusci/inspecao/dto/UploadZipResponse.java
+++ b/src/main/java/br/com/portfoliopelusci/inspecao/dto/UploadZipResponse.java
@@ -1,4 +1,29 @@
 package br.com.portfoliopelusci.inspecao.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "UploadZipResponse",
+        description = "Resumo do processamento do ZIP com fotos de inspeção."
+)
 public record UploadZipResponse(String inspetorId, int inspecoesAfetadas, int fotosSalvas) {
+
+    public UploadZipResponse(
+            @Schema(
+                    description = "Identificador do inspetor extraído do nome do arquivo ZIP.",
+                    example = "INSP-001"
+            ) String inspetorId,
+            @Schema(
+                    description = "Quantidade de inspeções (worders) criadas ou atualizadas.",
+                    example = "3"
+            ) int inspecoesAfetadas,
+            @Schema(
+                    description = "Quantidade total de fotos salvas no processamento.",
+                    example = "18"
+            ) int fotosSalvas
+    ) {
+        this.inspetorId = inspetorId;
+        this.inspecoesAfetadas = inspecoesAfetadas;
+        this.fotosSalvas = fotosSalvas;
+    }
 }


### PR DESCRIPTION
### Motivation
- Registrar no OpenAPI/Swagger o formato de retorno do endpoint de importação de ZIP para que consumidores entendam os campos retornados.
- Atender ao caminho solicitado `/foto-inspections/import-zip` mantendo compatibilidade com o endpoint existente `/inspecoes/upload-zip`.

### Description
- Atualizei `InspecaoUploadController` para expor o controller em `@RequestMapping({"/inspecoes", "/foto-inspections"})` e mapear o método em `@PostMapping({"/upload-zip", "/import-zip"})`.
- Adicionei anotações OpenAPI em `InspecaoUploadController` com `@Operation` e `@ApiResponses`, e referenciei `UploadZipResponse` no `201` via `@Schema(implementation = UploadZipResponse.class)`.
- Enriqueci o record `UploadZipResponse` com `@Schema` na classe e nas propriedades (descrição e `example`) para gerar documentação clara no Swagger.

### Testing
- Executado `./mvnw test -q`, que falhou devido a `Network is unreachable` ao tentar baixar dependências do Maven Wrapper.
- Executado `mvn -q -DskipTests compile`, que falhou com `Non-resolvable parent POM`/`403 Forbidden` ao resolver `org.springframework.boot:spring-boot-starter-parent` no Maven Central.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda234787c83228e900fd827cf58ee)